### PR TITLE
remove 'text here' placeholder

### DIFF
--- a/content/operator-capabilities.html
+++ b/content/operator-capabilities.html
@@ -191,7 +191,6 @@ c-0.5,0-0.6-0.2-0.6-0.6C125.1,45.8,125.1,42.7,125.1,39.6z"/>
 c0,4.7,0,9.4,0,14.1c0,0.6,0.1,0.8,0.8,0.8c2.1,0,4.1,0,6.2,0c0.5,0,0.7,0.1,0.6,0.6c0,1,0,2.1,0,3.1c0,0.4-0.1,0.6-0.6,0.6
 c-3.9,0-7.8,0-11.7,0c-0.5,0-0.6-0.2-0.6-0.6C142.4,45.8,142.4,42.7,142.4,39.6z"/>
 </svg>
-<p>text here</p>
 <h3 class="of-heading of-heading-md">Terminology</h3>
 <ul>
     <li><strong>Operator</strong> - the custom controller installed on a Kubernetes cluster</li>


### PR DESCRIPTION
Noticed this placeholder text while browsing the [capabilities section](https://operatorframework.io/operator-capabilities/) of the site, simple PR provide fix...

_Screenshot_:
<img width="1841" alt="Screen Shot 2020-11-19 at 9 50 10 AM" src="https://user-images.githubusercontent.com/10018904/99682005-c66f5c00-2a4c-11eb-9433-9163d18fe874.png">
