### PR TITLE
Point privacy policy to Linux Foundation site

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -100,7 +100,7 @@ c0.7-0.2,1.4,0.1,1.6,0.8C19.8,13.1,19.5,13.8,18.8,14.1 M13.1,9.9L9.9,11l1,3.1l3.
         document.write(new Date().getFullYear());
       </script></p>
       <ul class="of-link-list">
-        <li class="of-link-list__li"><a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a></li>        
+        <li class="of-link-list__li"><a href="https://www.linuxfoundation.org/privacy/">Privacy Statement</a></li>        
         <!-- <li class="of-link-list__li"><a href="">Terms of Use</a></li> -->
       </ul>
       <a class="of-footer-main__badge" href="https://www.netlify.com">


### PR DESCRIPTION
Since ownership of this site has been transferred to the LF, the privacy policy should link to the LF per RH legal team.