### PR TITLE
Kubecon refresh of Why splash page

### DIFF
--- a/content/why.html
+++ b/content/why.html
@@ -2,7 +2,7 @@
 title: "Why page"
 date: 2020-02-12T15:41:36-03:00
 draft: false
-menu: 
+menu:
     main:
         name: Why
         weight: 300
@@ -11,20 +11,20 @@ menu:
 <section class="of-section-page-intro">
     <header class="of-section-page-intro__header">
       <h1 class="of-heading of-heading--md">Why use the Operator Framework?</h1>
-    <p>If you are a community member, builder, consumer of applications, or a user of Kubernetes overall, the Operator Framework offers a number of benefits.</p>
+    <p>The Operator Framework makes it easier to build Kubernetes-native applications. It brings the expertise and knowledge of the Kubernetes community together in a single project. The project as a single goal: to lower the high barrier of entry that comes with developing Operators.</p>
     </header>
     <div class="of-section-page-intro__content">
         <h2 class="of-heading of-heading--md">For builders and the community</h2>
         <div class="of-section-page-intro__content__columns">
-            <p>Today, there is often a high barrier to entry when it comes to building Kubernetes applications. There are a substantial number of pre-existing dependencies and assumptions, many of which may require experience and technical knowledge. At the same time, application consumers often do not want their services to be siloed across IT footprints with disparate management capabilities (for example, departments with differing tools for auditing, notification, metering, and so on).</p>
-        <p>The Operator Framework aims to address these points by helping to bring the expertise and knowledge of the Kubernetes community together in a single project that, when used as a standard application package, can make it easier to build applications for Kubernetes. By sharing this Framework with the community, we hope to enable an ecosystem of builders to more easily create their applications on Kubernetes via a common method and also provide a standardized set of tools to build consistent applications.</p>
-        <p>We believe a proper extension mechanism to Kubernetes shouldn’t be built without the community. To this end, Red Hat has proposed a “platform-dev” Special Interest Group that aligns well with the existing Kubebuilder project from Google and we look forward to working with other industry leaders should this group come to fruition.</p>
-        <p>“We are working together with Red Hat and the broader Kubernetes community to help enable this ecosystem with an easier way to create and operate their applications on Kubernetes,” said Phillip Wittrock, Software Engineer at Google, Kubernetes community member, and member of the Kubernetes steering committee. “By working together on platform development tools, we strive to make Kubernetes the foundation of choice for container-native apps - no matter where they reside.”</p>
+            <p>The Operator Framework offers a standard application package for building and managing Operators. This allows Operator authors and cluster administrators to focus on meeting the needs of their customers, instead of dealing with the many dependencies, prerequisites, and assumptions involved with developing Kubernetes-native applications.</p>
+        <p>By sharing the Framework with the community, we want to create an ecosystem of builders. By providing a standardized set of
+tools to build consistent applications, these builders can easily create Kubernetes-native applications.</p>
+        <p>The Operator Framework is developed with the interests of the community and consumers in mind, because extending Kubernetes should not happen without community participation.</p>
         </div>
     </div>
     <footer class="of-section-page-intro__footer">
-        <h2 class="of-heading of-heading--md">FOR APPLICATION CONSUMERS AND KUBERNETES USERS</h2>
-    <p>For consumers of applications across the hybrid cloud, keeping those applications up to date as new versions become available is of supreme importance, both for security reasons and for managing the applications’ lifecycles and other needs. The Operator Framework helps address these user requirements, aiding in the creation of cloud-native applications that are easier to consume, to keep updated, and to secure.</p>
+        <h2 class="of-heading of-heading--md">For application consumers and Kubernetes users</h2>
+    <p>The Operator Framework addresses the concerns of consumers across the hybrid cloud. It does this by aiding in the creation of cloud-native applications and managing those applications' lifecycles so they are easier to consume, keep updated, and secure.</p>
     </footer>
 </section>
 <section class="of-capability-content">


### PR DESCRIPTION
Edit technical marketing content for the Why splash page.

I cut large portions of content that were important for the launch of the Operator Framework project, but seemed out-of-date now. As a result, this page seems a little thin, and the information about the Capability model for Operators is duplicated here and on the What splash page.

Does it make sense to consolidate these two pages? 

Let me know if these edits are too aggressive.
